### PR TITLE
Added some more functions:

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -25,11 +25,11 @@ These are the remaining GSSAPI calls to implement, in no particular order.
 - [ ] gss_import_sec_context
 - [ ] gss_indicate_mechs_by_attrs
 - [ ] gss_inquire_attrs_for_mech
-- [ ] gss_inquire_cred_by_oid
+- [X] gss_inquire_cred_by_oid
 - [ ] gss_inquire_mech_for_saslname
 - [ ] gss_inquire_name
 - [ ] gss_inquire_saslname_for_mech
-- [ ] gss_inquire_sec_context_by_oid
+- [X] gss_inquire_sec_context_by_oid
 - [ ] gss_krb5_ccache_name
 - [ ] gss_krb5_copy_ccache
 - [ ] gss_krb5_export_lucid_sec_context
@@ -46,7 +46,7 @@ These are the remaining GSSAPI calls to implement, in no particular order.
 - [ ] gss_process_context_token
 - [ ] gss_pseudo_random
 - [ ] gss_release_any_name_mapping
-- [ ] gss_release_buffer_set
+- [X] gss_release_buffer_set
 - [ ] gss_release_iov_buffer
 - [ ] gss_release_oid
 - [ ] gss_seal

--- a/buffer_test.go
+++ b/buffer_test.go
@@ -14,7 +14,7 @@ func TestNewBuffer(t *testing.T) {
 	}
 	defer l.Unload()
 
-	for a := range []int{allocNone, allocMalloc, allocGSSAPI} {
+	for _, a := range []allocType{allocNone, allocMalloc, allocGSSAPI} {
 		b, err := l.MakeBuffer(a)
 		if err != nil {
 			t.Fatalf("alloc: %v: %s", a, err)
@@ -28,10 +28,10 @@ func TestNewBuffer(t *testing.T) {
 			t.Fatalf("alloc: %v: b.Lib didn't get set correctly, got %p, expected %p",
 				a, b.Lib, l)
 		}
-		if b.C_gss_buffer_t == nil {
+		if a != allocNone && b.C_gss_buffer_t == nil {
 			t.Fatalf("alloc: %v: Got nil buffer, expected non-nil", a)
 		}
-		if b.String() != "" {
+		if a != allocNone && b.String() != "" {
 			t.Fatalf(`alloc: %v: String(): got %q, expected ""`,
 				a, b.String())
 		}

--- a/consts.go
+++ b/consts.go
@@ -15,6 +15,7 @@ package gssapi
 import "C"
 
 import (
+	"fmt"
 	"time"
 )
 
@@ -88,4 +89,13 @@ const (
 
 	// Infinite Lifetime, defined as 2^32-1
 	GSS_C_INDEFINITE = 0xffffffff * time.Second
+)
+
+var (
+	GSS_C_NO_CREDENTIAL *CredId = nil
+)
+
+// errors
+var (
+	ErrInvalidObject = fmt.Errorf("Object not initialized")
 )

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/sassoftware/gssapi
+
+go 1.14

--- a/gss_types.go
+++ b/gss_types.go
@@ -17,8 +17,10 @@ import "unsafe"
 // explicitly released.  Calling the Release method is safe on uninitialized
 // objects, and nil pointers.
 
+type allocType int
+
 const (
-	allocNone = iota
+	allocNone = allocType(iota)
 	allocMalloc
 	allocGSSAPI
 )
@@ -30,7 +32,7 @@ type Buffer struct {
 
 	// indicates if the contents of the buffer must be released with
 	// gss_release_buffer (allocGSSAPI) or free-ed (allocMalloc)
-	alloc int
+	alloc allocType
 }
 
 // A Name represents a binary string labeling a security principal. In the case
@@ -51,7 +53,7 @@ type OID struct {
 
 	// indicates if the contents of the buffer must be released with
 	// gss_release_buffer (allocGSSAPI) or free-ed (allocMalloc)
-	alloc int
+	alloc allocType
 }
 
 // An OIDSet is a set of OIDs.
@@ -63,7 +65,7 @@ type OIDSet struct {
 // A CredId represents information like a cryptographic secret. In Kerberos,
 // this likely represents a keytab.
 type CredId struct {
-	*Lib
+	lib             *Lib
 	C_gss_cred_id_t C.gss_cred_id_t
 }
 

--- a/misc.go
+++ b/misc.go
@@ -4,6 +4,7 @@ package gssapi
 
 /*
 #include <gssapi/gssapi.h>
+#include <gssapi/gssapi_ext.h>
 #include <stdlib.h>
 
 OM_uint32
@@ -20,6 +21,17 @@ wrap_gss_indicate_mechs(void *fp,
 			mech_set);
 
 	return maj;
+}
+
+OM_uint32
+wrap_gss_release_buffer_set( void* fp,
+	OM_uint32 * minor_status,
+	gss_buffer_set_t * buffer_set)
+{
+	return ((OM_uint32(*) (
+		OM_uint32 *,
+		gss_buffer_set_t *)
+	) fp) (minor_status, buffer_set);
 }
 
 */
@@ -42,4 +54,15 @@ func (lib *Lib) IndicateMechs() (*OIDSet, error) {
 	}
 
 	return mechs, nil
+}
+
+func (lib *Lib) ReleaseBufferSet(bs C.gss_buffer_set_t) error {
+	if nil == bs {
+		return nil
+	}
+	min := C.OM_uint32(0)
+	maj := C.wrap_gss_release_buffer_set(lib.Fp_gss_release_buffer_set,
+		&min,
+		&bs)
+	return lib.stashLastStatus(maj, min)
 }

--- a/name_test.go
+++ b/name_test.go
@@ -21,16 +21,16 @@ func TestNameImportExport(t *testing.T) {
 	}
 
 	makeName := func(n string) (name *Name) {
-		b, _ := l.MakeBufferString(n)
+		b, err := l.MakeBufferString(n)
+		defer b.Release()
 		if err != nil {
 			t.Fatalf("%q: Got error %v, expected nil", n, err)
 		}
 		if b == nil {
 			t.Fatalf("%q: Got nil, expected non-nil", n)
 		}
-		defer b.Release()
 
-		name, err := b.Name(l.GSS_C_NT_HOSTBASED_SERVICE)
+		name, err = b.Name(l.GSS_C_NT_HOSTBASED_SERVICE)
 		if err != nil {
 			t.Fatalf("%q: Got error %v, expected nil", n, err)
 		}

--- a/oid.go
+++ b/oid.go
@@ -152,6 +152,8 @@ func (oid *OID) DebugString() string {
 		return "GSS_MECH_IAKERB"
 	case bytes.Equal(oid.Bytes(), oid.GSS_MECH_NTLMSSP.Bytes()):
 		return "GSS_MECH_NTLMSSP"
+	case bytes.Equal(oid.Bytes(), oid.GSS_KRB5_GET_CRED_IMPERSONATOR.Bytes()):
+		return "GSS_KRB5_GET_CRED_IMPERSONATOR"
 	}
 
 	return oid.String()

--- a/spnego/spnego_server.go
+++ b/spnego/spnego_server.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/apcera/gssapi"
+	"github.com/sassoftware/gssapi"
 )
 
 // A ServerNegotiator is an interface that defines minimal functionality for

--- a/spnego/spnego_transport.go
+++ b/spnego/spnego_transport.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/apcera/gssapi"
+	"github.com/sassoftware/gssapi"
 )
 
 const negotiateScheme = "Negotiate"

--- a/spnego/spnego_transport_test.go
+++ b/spnego/spnego_transport_test.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/apcera/gssapi"
+	"github.com/sassoftware/gssapi"
 )
 
 func TestCheckSPNEGONegotiate(t *testing.T) {

--- a/test/client_access_test.go
+++ b/test/client_access_test.go
@@ -13,8 +13,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/apcera/gssapi"
-	"github.com/apcera/gssapi/spnego"
+	"github.com/sassoftware/gssapi"
+	"github.com/sassoftware/gssapi/spnego"
 )
 
 func initClientContext(t *testing.T, method, path string,

--- a/test/client_message_test.go
+++ b/test/client_message_test.go
@@ -10,7 +10,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/apcera/gssapi"
+	"github.com/sassoftware/gssapi"
 )
 
 func TestClientWrap(t *testing.T) {

--- a/test/docker/client/entrypoint.sh
+++ b/test/docker/client/entrypoint.sh
@@ -40,7 +40,7 @@ cat $KRB5_CONFIG_TEMPLATE \
 
 echo ${USER_PASSWORD} | kinit -V ${USER_NAME}@${REALM_NAME} >/dev/null
 
-(cd $TEST_DIR && go test -c -o test -tags 'clienttest' github.com/apcera/gssapi/test)
+(cd $TEST_DIR && go test -c -o test -tags 'clienttest' github.com/sassoftware/gssapi/test)
 
 # --test.bench=.
 # --test.benchtime=2s

--- a/test/docker/service/entrypoint.sh
+++ b/test/docker/service/entrypoint.sh
@@ -8,7 +8,7 @@ cat /tmp/krb5.conf.template \
         | sed -e "s/REALM_NAME/${REALM_NAME}/g" \
 	> /opt/go-gssapi-test-service/krb5.conf
 
-(cd /opt/go-gssapi-test-service && go test -c -o test -tags 'servicetest' github.com/apcera/gssapi/test)
+(cd /opt/go-gssapi-test-service && go test -c -o test -tags 'servicetest' github.com/sassoftware/gssapi/test)
 
 exec /opt/go-gssapi-test-service/test \
 	--test.v=true \

--- a/test/main_test.go
+++ b/test/main_test.go
@@ -11,7 +11,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/apcera/gssapi"
+	"github.com/sassoftware/gssapi"
 )
 
 const (

--- a/test/run.sh
+++ b/test/run.sh
@@ -167,14 +167,14 @@ fi
 
 # GSSAPI service
 log "Build and unit-test gssapi on host"
-go test github.com/apcera/gssapi
+go test github.com/sassoftware/gssapi
 
 build_image "service" "service-${env_suffix}" "$KEYTAB_FUNCTION" >/dev/null
 run_image "service" \
         "service-${env_suffix}" \
         "--detach \
         $DOCKER_KDC_OPTS \
-        --volume $TEST_DIR:/opt/go/src/github.com/apcera/gssapi" >/dev/null
+        --volume $TEST_DIR:/opt/go/src/github.com/sassoftware/gssapi" >/dev/null
 map_ports "service" 80
 wait_until_available "service" $SERVICE_PORT_80_TCP_ADDR $SERVICE_PORT_80_TCP_PORT
 
@@ -185,7 +185,7 @@ if [[ "$OSTYPE" != "darwin"* || "$CLIENT_IN_CONTAINER" != "" ]]; then
                 "client" \
                 "--link=service:service \
                 $DOCKER_KDC_OPTS \
-                --volume $TEST_DIR:/opt/go/src/github.com/apcera/gssapi"
+                --volume $TEST_DIR:/opt/go/src/github.com/sassoftware/gssapi"
 else
         log "Run gssapi sample client on host"
         KRB5_CONFIG_TEMPLATE=${DOCKER_DIR}/client/krb5.conf.template \

--- a/test/service.go
+++ b/test/service.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/apcera/gssapi"
+	"github.com/sassoftware/gssapi"
 )
 
 type loggingHandler struct {

--- a/test/service_access.go
+++ b/test/service_access.go
@@ -5,8 +5,8 @@ package test
 import (
 	"net/http"
 
-	"github.com/apcera/gssapi"
-	"github.com/apcera/gssapi/spnego"
+	"github.com/sassoftware/gssapi"
+	"github.com/sassoftware/gssapi/spnego"
 )
 
 func HandleAccess(c *Context, w http.ResponseWriter, r *http.Request) (code int, message string) {

--- a/test/service_credential_test.go
+++ b/test/service_credential_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/apcera/gssapi"
+	"github.com/sassoftware/gssapi"
 )
 
 func TestAcquireCredential(t *testing.T) {

--- a/test/service_message.go
+++ b/test/service_message.go
@@ -7,7 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"github.com/apcera/gssapi"
+	"github.com/sassoftware/gssapi"
 )
 
 // This test handler accepts the context, unwraps, and then re-wraps the request body

--- a/test/service_misc_test.go
+++ b/test/service_misc_test.go
@@ -7,7 +7,7 @@ package test
 import (
 	"testing"
 
-	"github.com/apcera/gssapi"
+	"github.com/sassoftware/gssapi"
 )
 
 func TestIndicateMechs(t *testing.T) {


### PR DESCRIPTION
gss_inquire_cred_by_oid, gss_inquire_sec_context_by_oid, and gss_release_buffer_set.

Added GSS_KRB5_GET_CRED_IMPERSONATOR constant.

refactored credential receiver name to "cred"
Inquire*ByOID will return error if it fails to make bytes array

first pass refactoring to sassoftware instead of apcera

Made unit tests happy

krb5_free_context function pointer was causing segfault, so we don't call it any more, fix eventually.
removed errors library usage.

go mod init

all CredId functions are no-op if lib is nil

move to nil for GSS_C_NO_CREDENTIAL

allow Kinit to get forwardable and/or proxiable ticket